### PR TITLE
Fix the exposed port for MySQL image

### DIFF
--- a/docker/dbms/MySQL/Dockerfile
+++ b/docker/dbms/MySQL/Dockerfile
@@ -9,4 +9,7 @@ ENV TZ=Europe/Amsterdam \
 
 COPY create_user.sql /docker-entrypoint-initdb.d/
 
-EXPOSE 3306
+RUN echo "[mysqld]" >> /etc/my.cnf
+RUN echo "port=3307" >> /etc/my.cnf
+
+EXPOSE 3307

--- a/docker/dbms/MySQL/Dockerfile
+++ b/docker/dbms/MySQL/Dockerfile
@@ -9,7 +9,4 @@ ENV TZ=Europe/Amsterdam \
 
 COPY create_user.sql /docker-entrypoint-initdb.d/
 
-# Change port so mysql can be run together with mariadb
-CMD ["mysqld", "--port", "3307"]
-
-EXPOSE 3307
+EXPOSE 3306

--- a/docker/dbms/MySQL/docker-compose.yml
+++ b/docker/dbms/MySQL/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     restart: unless-stopped
     ports:
-      - 3307:3307
+      - "3307:3306"

--- a/docker/dbms/MySQL/docker-compose.yml
+++ b/docker/dbms/MySQL/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     restart: unless-stopped
     ports:
-      - "3307:3306"
+      - "3307:3307"


### PR DESCRIPTION
MySQL was listening on port 3306 instead of 3307, but the compose file did not map that port so no connection could be made to the database.

By exposing instead 3306 and then mapping that to 3307 in the compose file this is fixed.

As long as the CI runs the databases using the compose-files this should expose the correct port without conflicting with MariaDB, or breaking the datasource URLs.